### PR TITLE
Fix parsing of cif files in cases where there is a uncertainty label,…

### DIFF
--- a/manage_crystal/file_parser.py
+++ b/manage_crystal/file_parser.py
@@ -8,6 +8,7 @@ from manage_crystal.periodic_table import ptab_atnum_inv
 import numpy as np
 import os
 import sys
+import re 
 from six.moves import range
 
 ANGS2BOHR = 1.88973
@@ -86,17 +87,17 @@ def parse_cif(file):
         if line == "":
             break
         if len(data) > 0 and (data[0] == "_cell_length_a"):
-            c.length[0] = float(data[1])
+            c.length[0] = float(re.sub(r'\([^)]*\)', '', data[1]))
         if len(data) > 0 and (data[0] == "_cell_length_b"):
-            c.length[1] = float(data[1])
+            c.length[1] = float(re.sub(r'\([^)]*\)', '', data[1]))
         if len(data) > 0 and (data[0] == "_cell_length_c"):
-            c.length[2] = float(data[1])
+            c.length[2] = float(re.sub(r'\([^)]*\)', '', data[1]))
         if len(data) > 0 and (data[0] == "_cell_angle_alpha"):
-            c.angle_deg[0] = float(data[1])
+            c.angle_deg[0] = float(re.sub(r'\([^)]*\)', '', data[1]))
         if len(data) > 0 and (data[0] == "_cell_angle_beta"):
-            c.angle_deg[1] = float(data[1])
+            c.angle_deg[1] = float(re.sub(r'\([^)]*\)', '', data[1]))
         if len(data) > 0 and (data[0] == "_cell_angle_gamma"):
-            c.angle_deg[2] = float(data[1])
+            c.angle_deg[2] = float(re.sub(r'\([^)]*\)', '', data[1]))
         # if the "_atom_site_***" section starts, remember the order
         if len(data) > 0 \
            and len(data[0].split("_")) > 1 \

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ if __name__ == '__main__':
         extras_require={
             "testing": [
                 "mock==2.0.0", "pgtest==1.1.0", "sqlalchemy-diff==0.1.3",
-                "wheel>=0.31", "coverage"
+                "wheel>=0.31", "coverage", "pytest"
             ],
             "pre-commit": [
                 "pre-commit==1.11.0",

--- a/tests/input_cif/LEV.cif
+++ b/tests/input_cif/LEV.cif
@@ -1,0 +1,76 @@
+data_LEV
+#**************************************************************************
+#
+# CIF taken from the IZA-SC Database of Zeolite Structures
+# Ch. Baerlocher and L.B. McCusker
+# Database of Zeolite Structures: http://www.iza-structure.org/databases/ 
+#
+# The atom coordinates and the cell parameters were optimized with DLS76
+# assuming a pure SiO2 composition.
+#
+#**************************************************************************
+
+_cell_length_a                  13.1680(0)
+_cell_length_b                  13.1680(0)
+_cell_length_c                  22.5780(0)
+_cell_angle_alpha               90.0000(0)
+_cell_angle_beta                90.0000(0)
+_cell_angle_gamma              120.0000(0)
+
+_symmetry_space_group_name_H-M     'R -3 m'
+_symmetry_Int_Tables_number         166
+_symmetry_cell_setting             trigonal
+
+loop_
+_symmetry_equiv_pos_as_xyz
+'+x,+y,+z'
+'2/3+x,1/3+y,1/3+z'
+'1/3+x,2/3+y,2/3+z'
+'-y,+x-y,+z'
+'2/3-y,1/3+x-y,1/3+z'
+'1/3-y,2/3+x-y,2/3+z'
+'-x+y,-x,+z'
+'2/3-x+y,1/3-x,1/3+z'
+'1/3-x+y,2/3-x,2/3+z'
+'-y,-x,+z'
+'2/3-y,1/3-x,1/3+z'
+'1/3-y,2/3-x,2/3+z'
+'-x+y,+y,+z'
+'2/3-x+y,1/3+y,1/3+z'
+'1/3-x+y,2/3+y,2/3+z'
+'+x,+x-y,+z'
+'2/3+x,1/3+x-y,1/3+z'
+'1/3+x,2/3+x-y,2/3+z'
+'-x,-y,-z'
+'2/3-x,1/3-y,1/3-z'
+'1/3-x,2/3-y,2/3-z'
+'+y,-x+y,-z'
+'2/3+y,1/3-x+y,1/3-z'
+'1/3+y,2/3-x+y,2/3-z'
+'+x-y,+x,-z'
+'2/3+x-y,1/3+x,1/3-z'
+'1/3+x-y,2/3+x,2/3-z'
+'+y,+x,-z'
+'2/3+y,1/3+x,1/3-z'
+'1/3+y,2/3+x,2/3-z'
+'+x-y,-y,-z'
+'2/3+x-y,1/3-y,1/3-z'
+'1/3+x-y,2/3-y,2/3-z'
+'-x,-x+y,-z'
+'2/3-x,1/3-x+y,1/3-z'
+'1/3-x,2/3-x+y,2/3-z'
+
+loop_
+_atom_site_label
+_atom_site_type_symbol
+_atom_site_fract_x
+_atom_site_fract_y
+_atom_site_fract_z
+    O1    O     0.0955    0.1910    0.0771
+    O2    O     0.0347    0.3448    0.1097
+    O3    O     0.8724    0.1276    0.0862
+    O4    O     0.0000    0.2678    0.0000
+    O5    O     0.1127    0.8873    0.4881
+    T1    Si    0.0005    0.2327    0.0683
+    T2    Si    0.2397    0.0000    0.5000
+

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,0 +1,26 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+import os
+from manage_crystal import file_parser
+
+THIS_DIR = os.path.dirname(__file__)
+
+def test_cif_parser():
+    # test file with uncertainty
+    crystal = file_parser.parse_from_filepath(os.path.join('input_cif', 'LEV.cif'), tm=None)
+    assert crystal.length[0] == 13.1680
+    assert crystal.length[1] == 13.1680
+    assert crystal.length[2] == 22.5780
+    assert crystal.angle_deg[0] == 90.0000
+    assert crystal.angle_deg[1] == 90.0000
+    assert crystal.angle_deg[2] == 120.0000
+
+    # test file without uncertainty
+    crystal = file_parser.parse_from_filepath(os.path.join('input_cif', 'core-cof.cif'), tm=None)
+    assert crystal.length[0] == 23.4486008
+    assert crystal.length[1] == 23.4486008
+    assert crystal.length[2] == 3.9693000
+    assert crystal.angle_deg[0] == 90.0000000
+    assert crystal.angle_deg[1] == 90.0000
+    assert crystal.angle_deg[2] == 120.0000


### PR DESCRIPTION
Hi Daniele, 

I just wanted to parse a `.cif ` that comes from the IZA zeolite database (i.e. `LEV.cif`) but it failed due to the uncertainty label. This pull request fixes this. I also added a test case for this specific failure and one of the old `.cif` files you had in the test directory. 

In introduce two new dependencies:
- pytest for the unittest
- re for removal of the uncertainty label 
